### PR TITLE
📝 docs(agents): adopt PR-based delivery workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ Personal site built with React 19 + TypeScript (Vite, Vitest, `pnpm@9.15.2`).
 - Use native `gh` CLI when working with GitHub issues/PRs.
 - Commit format: `<emoji> <type>(<scope>): <summary>`.
 - Types: `✨ feat`, `🐛 fix`, `🧹 chore`, `♻️ refactor`, `📝 docs`, `✅ test`, `🎨 style`, `⚡ perf`, `♿ a11y`, `👷 ci`, `🔧 build`.
+- Flow: `gh issue view` -> implement -> validate -> commit (`Closes #123` / `Fixes #123` when completed; `Refs #123` otherwise) -> push branch -> create PR with `gh pr create` -> merge -> `gh issue close` only if auto-close did not trigger.
+- Default delivery path: create a branch, push it, and create a PR for every change; do not push directly to `main`.
+- When asked to "commit and push", treat it as "commit, push, and open a PR" unless explicitly told not to create a PR.
+- Optional: `gh issue develop <number> --checkout`.
 - Subject rules: imperative mood, specific summary, target <72 chars.
 - Body rules: 1-3 short lines that explain why/impact, not file-by-file diffs.
 - If linked to work items: use `Closes #123` / `Fixes #123` for completed work, `Refs #123` otherwise.


### PR DESCRIPTION
## Summary
- add PR-first delivery flow to AGENTS.md
- require branch + PR for changes (no direct pushes)
- define "commit and push" as commit + push + open PR by default

## Validation
- docs-only change; no code/test impact