### PR TITLE
🐛 fix(deploy): support Vercel SPA routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a Vercel catch-all rewrite so direct SPA routes serve the React entry point.

This keeps preview and production URLs working when client-side routes are opened or refreshed directly.

Checks: `pnpm lint`, `pnpm test`, `pnpm build`.